### PR TITLE
Bug fix in ARDENT_AddPlanets and update with phase angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![ARDENT Logo](logo/ARDENTlogo.png)
+<img src="https://github.com/manustalport/ardent/blob/Dvp/logo/ARDENT_Wbg.png" width=400>
 
 # ARDENT
 The Algorithm for the Refinement of DEtection limits via N-body stability Threshold (ARDENT) is a python package for the computation of exoplanet detection limits from radial velocity data. In addition to the classic data-driven detection limits, ARDENT includes the orbital stability constraint (what we call dynamical detection limits). The final output is a more constraining detection limits curve, taking into account both the detectability of potential planets and their dynamical plausibility. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/manustalport/ardent/blob/Dvp/logo/ARDENT_Wbg.png" width=400>
+<img src="https://github.com/manustalport/ardent/blob/Dvp/logo/ARDENT_Wbg.png" width=500>
 
 # ARDENT
 The Algorithm for the Refinement of DEtection limits via N-body stability Threshold (ARDENT) is a python package for the computation of exoplanet detection limits from radial velocity data. In addition to the classic data-driven detection limits, ARDENT includes the orbital stability constraint (what we call dynamical detection limits). The final output is a more constraining detection limits curve, taking into account both the detectability of potential planets and their dynamical plausibility. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://github.com/manustalport/ardent/blob/Dvp/logo/ARDENT_Wbg.png" width=500>
 
 # ARDENT
-The Algorithm for the Refinement of DEtection limits via N-body stability Threshold (ARDENT) is a python package for the computation of exoplanet detection limits from radial velocity data. In addition to the classic data-driven detection limits, ARDENT includes the orbital stability constraint (what we call dynamical detection limits). The final output is a more constraining detection limits curve, taking into account both the detectability of potential planets and their dynamical plausibility. 
+The Algorithm for the Refinement of DEtection limits via N-body stability Threshold (ARDENT) is a Python package for the computation of exoplanet detection limits from radial velocity data. In addition to the classic data-driven detection limits, ARDENT includes the orbital stability constraint (what we call dynamical detection limits). The final output is a more constraining detection limits curve, taking into account both the detectability of potential planets and their dynamical plausibility. 
 
 The code can be used as two separate modules, for the data-driven detection limits and the dynamical detection limits. ARDENT can be used to refine the detection limits, test the dynamical plausibility of a planet candidate, and check if there is dynamical room for additional planets in a certain period range. 
 

--- a/ardent/ardent.py
+++ b/ardent/ardent.py
@@ -1,12 +1,12 @@
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 import getopt
 import os
 import pickle
 import sys
 
-from . import ardent_functions as ardf
-# import ardent_functions as ardf
+#from . import ardent_functions as ardf
+import ardent_functions as ardf
 import matplotlib.colors as mcolors
 import numpy as np
 import pandas as pd
@@ -145,7 +145,7 @@ class ARDENT_tableXY(object):
         self.ARDENT_ShowPlanets()
 
 
-    def ARDENT_AddPlanets(self, p=365.25, semi_major=np.nan, mean_long=0.0, mean_anomaly=np.nan, peri_time=np.nan, e=0.0, elower=np.nan, omega=0.0, inc=90.0, asc_node=0.0, k=0.10, mass=np.nan):
+    def ARDENT_AddPlanets(self, p=np.nan, semi_major=np.nan, mean_long=np.nan, mean_anomaly=np.nan, peri_time=np.nan, e=np.nan, elower=np.nan, omega=np.nan, inc=90.0, asc_node=0.0, k=np.nan, mass=np.nan):
         """
         Add a planet to ARDENT, by specifying its mass and orbital elements. Either the mean_long, mean_anomaly, or time of pericenter passage is needed.
         
@@ -155,32 +155,58 @@ class ARDENT_tableXY(object):
             semi_major : semi_major axis [AU]
             mean_long : mean longitude [deg]
             mean_anomaly : mean anomaly [deg]
-            peri_time : time of pericenter passage
+            peri_time : time of pericenter passage [days]
             e : orbital eccentricity
             elower (optional) : The lower orbital eccentricity compatible with the observations, typically the 1-sigma lower limit. In case of significant uncertainties on the eccentricities, it is recommended to provide this parameter.
             omega : argument of periastron [deg]
-            inc : orbital inclination [deg]
-            asc_node : longitude of the ascending node [deg]
+            inc : orbital inclination [deg] (default=90 deg).
+            asc_node : longitude of the ascending node [deg] (default=0 dag).
             k : RV semi-amplitude [m/s]
             mass : planetary mass [M_Earth]
         """
-        if np.isnan(elower) == False:
-            print('\n [INFO] Orbital eccentricity: the lower limit is adopted as the nominal value (%.3f)'%(elower))
+        error = int(0)
+        
+        if p!=p:
+            print('\n [ERROR] Orbital period required! Provide p [days].')
+            error+=1
+            
+        if k!=k:
+            print('\n [ERROR] RV semi-amplitude required! Provide k [m/s].')
+            error+=1
+            
+        if e!=e and elower!=elower:
+            print('\n [ERROR] Orbital eccentricity required! Provide either e or elower.')
+            error+=1
+            
+        if mean_long!=mean_long and mean_anomaly!=mean_anomaly and peri_time!=peri_time:
+            print('\n [ERROR] Orbital phase required! Provide either mean_long [deg], mean_anomaly [deg], or peri_time.')
+            error+=1
+            
+        if elower==elower:
             e = elower
-
-        if (semi_major!=semi_major)|(mass!=mass):
-            mass_comp,semi_major_comp = ardf.AmpStar(self.mstar, p, k, e=e, i=inc)
-        
-        if mass!=mass:
-            mass = mass_comp
-            print('\n [INFO] Mass calculated to be %.2f Earth mass'%(mass))
-        
-        if semi_major!=semi_major:
-            semi_major = semi_major_comp
-            print('\n [INFO] Semi-major axis calculated to be %.2f AU'%(semi_major))
-
-        self.planets.append([p, semi_major, mean_long, mean_anomaly, peri_time, e, omega, inc, asc_node, k, mass])
-        self.ARDENT_ShowPlanets()
+        if e > 0 and omega!=omega:
+            print('\n [ERROR] Argument of periastron required if e>0! Provide omega [deg].')
+            error += 1
+            
+        if error == 0:
+            if elower==elower:
+                print('\n [INFO] Orbital eccentricity: the lower limit is adopted as the nominal value (%.3f)'%(elower))
+            if e==0 and omega!=omega:
+                print('\n [INFO] Argument of periastron of circular orbit not provided. Arbitrarily set to 90 deg.')
+                omega=90.
+                                
+            if (semi_major!=semi_major)|(mass!=mass):
+                mass_comp,semi_major_comp = ardf.AmpStar(self.mstar, p, k, e=e, i=inc)
+                if mass!=mass:
+                    mass = mass_comp
+                    print('\n [INFO] Mass calculated to be %.2f Earth mass'%(mass))
+            
+                if semi_major!=semi_major:
+                    semi_major = semi_major_comp
+                    print('\n [INFO] Semi-major axis calculated to be %.2f AU'%(semi_major))
+                    
+            self.planets.append([p, semi_major, mean_long, mean_anomaly, peri_time, e, omega, inc, asc_node, k, mass])
+            self.ARDENT_ShowPlanets()
 
 
     def ARDENT_ShowPlanets(self):
@@ -615,19 +641,21 @@ class ARDENT_tableXY(object):
                 subP_means, M95 = ardf.Stat_DataDL(self.output_file_DL, nbins=nbins, percentage=95)
                 output = pd.read_pickle(self.output_file_DL)
                 rangeP = output['rangeP']
+                InjectionRecoveryFile = self.output_file_DL
+                split_filename = InjectionRecoveryFile.split('_')[-1]
+                version_dataDL = int(split_filename.split('.')[0])
             else: # ARDENT recomputes data-driven detection limits (with nbins bins) prior to computing the dynamical detection limits. It is possible to skip the ARDENT computation of data DL, in which case ExternalDataDL must be provided.
                 subP_means, M95 = ExternalDataDL[0], ExternalDataDL[1]
                 rangeP = np.array([subP_means[0], subP_means[-1]])
-                
-            InjectionRecoveryFile = self.output_file_DL
-                
+                version_dataDL = int(0)
+                                
         else:
             subP_means, M95 = ardf.Stat_DataDL(InjectionRecoveryFile, nbins=nbins, percentage=95)
             output = pd.read_pickle(InjectionRecoveryFile)
             rangeP = output['rangeP']
+            split_filename = InjectionRecoveryFile.split('_')[-1]
+            version_dataDL = int(split_filename.split('.')[0])
             
-        split_filename = InjectionRecoveryFile.split('_')[-1]
-        version_dataDL = int(split_filename.split('.')[0])
         version_dynDL = int(0)
         self.output_file_STDL1 = self.tag+"AllStabilityRates_%d_Run%d.dat"%(version_dataDL,version_dynDL)
         output_file = self.output_file_STDL1

--- a/ardent/ardent_functions.py
+++ b/ardent/ardent_functions.py
@@ -60,7 +60,7 @@ def AmpStar(ms, P, K, e=0., i=90.):
     """
     if type(i) == float or type(i) == int:
         if i == 0:
-            print('[WARNING] Orbital inclination of at least one body set to 0 degrees')
+            print('[WARNING] Orbital inclination of at least one body set to 0 degrees!')
     
     i = ang_rad(i) # Conversion in  radians, in [-pi,pi[
     mp = (np.sqrt(1-e**2)/np.sin(i)) * (K/28.435) * ms**(2./3.) * (P/365.25)**(1./3.) # [M_Jup] -- valid for any e and i
@@ -69,6 +69,32 @@ def AmpStar(ms, P, K, e=0., i=90.):
     a = (P/365.25)**(2./3.) * ((ms+mp*mE_S)/(1.+mE_S))**(1./3.)
 
     return mp, a
+    
+def RV_SemiAmp(ms, mp, P, e=0., i=90.):
+    """
+    Function computing the RV semi-amplitude given planet mass.
+    
+    Arguments
+    ---------
+    ms (float or 1D array): stellar mass [M_Sun]
+    mp (float or 1D array): planet mass [M_Earth]
+    P (float or 1D array): orbital period [days]
+    e (float or 1D array, optional): the orbital eccentricity (default=0)
+    i (float or 1D array, optional): the orbital inclination [deg] (default=90)
+    
+    Output
+    ------
+    k (float or 1D array): RV semi-amplitude [m/s]
+    """
+    if type(i) == float or type(i) == int:
+        if i == 0:
+            print('[WARNING] Orbital inclination of at least one body set to 0 degrees! For edge-on, set i to 90 deg.')
+    
+    i = ang_rad(i) # Conversion in  radians, in [-pi,pi[
+    k = (28.4329/np.sqrt(1-e**2)) * mp*mE_J*np.sin(i) * ms**(-2./3.) * (P/365.25)**(-1./3.)
+    
+    return k
+    
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% MODULE 1: data-driven detection limits %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% #
@@ -421,27 +447,25 @@ def Stability(KepParam, phase_param, Mstar, T, dt, min_dist, max_dist, max_drift
     
     sim = rebound.Simulation()
     sim.add(m=Mstar)
-    
-    if phase_param == 'mean_long': # Mean Longitude is provided
-        sim.add(m=M[0], a=a[0], l=phase[0], omega=w[0], e=e[0], Omega=O[0], inc=inc[0])
-        q = int(1)
-        while q < len(a):
+
+    for q in range(Nbodies):
+        ### Mean longitude
+        if phase_param[q] == 'mean_long' and q == 0:
+            sim.add(m=M[0], a=a[0], l=phase[0], omega=w[0], e=e[0], Omega=O[0], inc=inc[0])
+        elif phase_param[q] == 'mean_long' and q > 0:
             sim.add(primary=sim.particles[0], m=M[q], a=a[q], l=phase[q], omega=w[q], e=e[q], Omega=O[q], inc=inc[q])
-            q += 1
-            
-    elif phase_param == 'pericenter_time': # Time of pericenter passage is provided
-        sim.add(m=M[0], a=a[0], T=phase[0], omega=w[0], e=e[0], Omega=O[0], inc=inc[0])
-        q = int(1)
-        while q < len(a):
+        ### Time of pericenter
+        elif phase_param[q] == 'pericenter_time' and q == 0:
+            sim.add(m=M[0], a=a[0], T=phase[0], omega=w[0], e=e[0], Omega=O[0], inc=inc[0])
+        elif phase_param[q] == 'pericenter_time' and q > 0:
             sim.add(primary=sim.particles[0], m=M[q], a=a[q], T=phase[q], omega=w[q], e=e[q], Omega=O[q], inc=inc[q])
-            q += 1
-            
-    else: # Mean Anomaly is provided
-        sim.add(m=M[0], a=a[0], M=phase[0], omega=w[0], e=e[0], Omega=O[0], inc=inc[0])
-        q = int(1)
-        while q < len(a):
+        ### Mean anomaly
+        elif phase_param[q] == 'mean_anomaly' and q == 0:
+            sim.add(m=M[0], a=a[0], M=phase[0], omega=w[0], e=e[0], Omega=O[0], inc=inc[0])
+        elif phase_param[q] == 'mean_anomaly' and q > 0:
             sim.add(primary=sim.particles[0], m=M[q], a=a[q], M=phase[q], omega=w[q], e=e[q], Omega=O[q], inc=inc[q])
-            q += 1
+
+
       
     sim.move_to_com()
     sim.dt = dt * 2*np.pi # Conversion to rebound units: 1yr = 2pi
@@ -559,20 +583,23 @@ def DynDL(shift, output_file1, output_file2, keplerian_table, D95, nbins, inc_in
     inc = ang_rad(np.array(table_keplerian['inc']))
     M = np.array(table_keplerian['mass']) *mE_S                # [MSun]
     a = np.array(table_keplerian['semimajor'])                 # [AU]
-    
+
     mean_long = np.array(table_keplerian['mean_long'])
     mean_anomaly = np.array(table_keplerian['mean_anomaly'])
     peri_time = np.array(table_keplerian['pericenter_time'])
-    if np.sum(np.isnan(mean_long)) == 0:
-        phase = ang_rad(mean_long)
-        phase_param = 'mean_long'
-    elif np.sum(np.isnan(peri_time)) == 0:
-        phase = ang_rad(peri_time)
-        phase_param = 'pericenter_time'
-    else:
-        phase = ang_rad(mean_anomaly)
-        phase_param = 'mean_anomaly'
-    
+    phase = np.zeros(Nplanets+1) # Planets + the injected one
+    phase_param = []
+    for i in range(Nplanets+1):
+        if np.isnan(mean_long[i]) == False: # This condition is always met for the injected planet, since all phase angles are set to 0 at this stage (assigned different values below). Thus, it is always mean_long that is used for the injected planet.
+            phase[i] = ang_rad(mean_long[i]) # Angle units in REBOUND are radians.
+            phase_param = np.append(phase_param, 'mean_long')
+        elif np.isnan(peri_time[i]) == False:
+            phase[i] = (peri_time[i]/365.25) * 2*np.pi # Time units in REBOUND are 2pi/yr.
+            phase_param = np.append(phase_param, 'pericenter_time')
+        else:
+            phase[i] = ang_rad(mean_anomaly[i]) # Angle units in REBOUND are radians.
+            phase_param = np.append(phase_param, 'mean_anomaly')
+            
     params = [a,phase,e,w,inc,O,M] # Keep the order of the elements! a,phase,e,w,inc,O,M
     phases_inject = np.linspace(-np.pi, np.pi, Nphases, endpoint=False) # With endpoint=False, generate Nphases points with constant interval in [start, stop[ (the last value is excluded)
     if type(inc_inject) == float or type(inc_inject) == int:
@@ -589,7 +616,7 @@ def DynDL(shift, output_file1, output_file2, keplerian_table, D95, nbins, inc_in
     
     if type(ecc_inject) == float or type(ecc_inject) == int:
         ecc_inject = np.zeros(Nphases) + ecc_inject
-        w_inject = np.zeros(Nphases)
+        w_inject = np.zeros(Nphases) + np.pi/4 # Default is 90deg (in rad for REBOUND)
     elif ecc_inject == 'beta':
         ecc_inject = np.random.beta(0.867,3.03,size=Nphases)
         w_inject = np.array([uniform(-np.pi, np.pi) for i in range(Nphases)])
@@ -851,4 +878,6 @@ def LongTermStab(output_file, keplerian_table, Mstar, T=None, dt=None, min_dist=
         
     except rebound.Encounter:
         print(' [INFO] --Long term stability-- Simulation stopped! Close encounter. ')
+
+
 


### PR DESCRIPTION
Bug fix in ardent.py, `ARDENT_AddPlanets`: instead of assuming orbital parameter values if not provided, ARDENT now returns a targeted error message. This solved also a bug with phase angles definition. Because mean_long was assumed 0 if not provided, if the user entered another phase angle instead (e.g. mean_anomaly) the REBOUND simulations were always initiated with the mean_long phase angle set to 0, not accounting for the other phase angle. This bug is now fixed. 

Update: In addition, it is now possible to use a different definition of phase angle per planet (e.g. mean_long for one planet, time of pericenter for another). Modifications brought to ardent_functions.py `DynDL` and `Stability` functions. 